### PR TITLE
Add WorldTime module.

### DIFF
--- a/lib/world_time.ex
+++ b/lib/world_time.ex
@@ -10,7 +10,6 @@ defmodule WorldTime do
   @enforce_keys [:multiplier, :start]
   defstruct [:multiplier, :start]
 
-  # TODO: Upper limit should be defined as well.
   def start(multiplier) when multiplier <= 0, do: {:error, :badarg}
 
   def start(multiplier) do

--- a/lib/world_time.ex
+++ b/lib/world_time.ex
@@ -14,10 +14,14 @@ defmodule WorldTime do
   def start(multiplier) when multiplier <= 0, do: {:error, :badarg}
 
   def start(multiplier) do
-    start = NaiveDateTime.utc_now
-    Agent.start_link(fn ->
-      %WorldTime{multiplier: multiplier, start: start}
-    end, name: __MODULE__)
+    start = NaiveDateTime.utc_now()
+
+    Agent.start_link(
+      fn ->
+        %WorldTime{multiplier: multiplier, start: start}
+      end,
+      name: __MODULE__
+    )
   end
 
   def stop do
@@ -25,7 +29,8 @@ defmodule WorldTime do
   end
 
   def now() do
-    now = NaiveDateTime.utc_now
+    now = NaiveDateTime.utc_now()
+
     Agent.get(__MODULE__, fn %WorldTime{multiplier: m, start: s} ->
       NaiveDateTime.add(@unit_epoch, NaiveDateTime.diff(now, s) * m)
     end)

--- a/lib/world_time.ex
+++ b/lib/world_time.ex
@@ -1,0 +1,35 @@
+defmodule WorldTime do
+  use Agent
+
+  @unit_epoch ~N[2016-11-16 08:42:00]
+
+  @type t :: %__MODULE__{
+          multiplier: number(),
+          start: NaiveDateTime.t()
+        }
+  @enforce_keys [:multiplier, :start]
+  defstruct [:multiplier, :start]
+
+  # TODO: Upper limit should be defined as well.
+  def start(multiplier) when multiplier <= 0, do: {:error, :badarg}
+
+  def start(multiplier) do
+    start = NaiveDateTime.utc_now
+    Agent.start_link(fn ->
+      %WorldTime{multiplier: multiplier, start: start}
+    end, name: __MODULE__)
+  end
+
+  def stop do
+    Agent.stop(__MODULE__)
+  end
+
+  def now() do
+    now = NaiveDateTime.utc_now
+    Agent.get(__MODULE__, fn %WorldTime{multiplier: m, start: s} ->
+      NaiveDateTime.add(@unit_epoch, NaiveDateTime.diff(now, s) * m)
+    end)
+  end
+
+  def epoch, do: @unit_epoch
+end

--- a/test/world_time_test.exs
+++ b/test/world_time_test.exs
@@ -14,13 +14,13 @@ defmodule WorldTimeTest do
     {:error, :badarg} = WorldTime.start(0)
     {:error, :badarg} = WorldTime.start(-1)
   end
-  
+
   test "WorldTime agent correctly applies multiplier" do
     Enum.map(1..5, fn multiplier ->
-        {:ok, _} = WorldTime.start(multiplier)
-        Process.sleep(1000)
-        assert NaiveDateTime.add(WorldTime.epoch, multiplier) == WorldTime.now
-        WorldTime.stop
-      end)
+      {:ok, _} = WorldTime.start(multiplier)
+      Process.sleep(1000)
+      assert NaiveDateTime.add(WorldTime.epoch(), multiplier) == WorldTime.now()
+      WorldTime.stop()
+    end)
   end
 end

--- a/test/world_time_test.exs
+++ b/test/world_time_test.exs
@@ -1,0 +1,26 @@
+defmodule WorldTimeTest do
+  use ExUnit.Case
+
+  test "starts the WorldTime agent without issues" do
+    {:ok, _} = WorldTime.start(1)
+  end
+
+  test "WorldTime.now/0 does not throw" do
+    {:ok, _} = WorldTime.start(1)
+    _time = WorldTime.now()
+  end
+
+  test "WorldTime agent rejects negative multipliers" do
+    {:error, :badarg} = WorldTime.start(0)
+    {:error, :badarg} = WorldTime.start(-1)
+  end
+  
+  test "WorldTime agent correctly applies multiplier" do
+    Enum.map(1..5, fn multiplier ->
+        {:ok, _} = WorldTime.start(multiplier)
+        Process.sleep(1000)
+        assert NaiveDateTime.add(WorldTime.epoch, multiplier) == WorldTime.now
+        WorldTime.stop
+      end)
+  end
+end


### PR DESCRIPTION
WorldTime is used to track a time within the simulation. The module
allows to specify a multiplier to control the 'speed of time'.